### PR TITLE
Use correct option in conda-incubator

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -66,7 +66,7 @@ jobs:
         architecture: x64
 
         miniforge-variant: Mambaforge
-        uses-mamba: true
+        use-mamba: true
         channels: conda-forge, defaults
 
         activate-environment: mdakithole2-test


### PR DESCRIPTION
Previous option was `uses-mamba: true`, but it should instead be `use-mamba: true`. The original CI output a warning, but did not fail. Check the raw logs for the warning before merging.
