### PR TITLE
Use conda-forge channel instead of a personal one

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,7 +1,6 @@
 name: mdakithole2-test
 channels: 
   - conda-forge 
-  - rulemaster
   - defaults
 dependencies:
   - python


### PR DESCRIPTION
Since hole2 was added to conda-forge, we can remove the reference to my personal channel.