### PR TITLE
Python version bump

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -43,7 +43,7 @@ jobs:
         matrix:
           # os: [macOS-latest, ubuntu-latest, windows-latest]
           os: [ubuntu-latest]
-          python-version: ["3.8", "3.9", "3.10"]
+          python-version: ["3.9", "3.10", "3.11"]
           mdanalysis-version: ["latest", "develop"]
 
     steps:

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,7 +1,6 @@
 name: mdakithole2-test
 channels: 
   - conda-forge 
-  - rulemaster
   - defaults
 dependencies:
   - python

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: mdakithole2
-  version: "0.1.0"
+  version: "0.2.0"
 
 source:
   path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
     {name = "Ian Kenney", email = "ikenney@asu.edu"},
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "MDAnalysis>=2.0.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     # Customize MANIFEST.in if the general case does not suit your needs
     # Comment out this line to prevent the files from being packaged with your software
     include_package_data=True,
-    python_requires=">=3.8",          # Python version restrictions
+    python_requires=">=3.9",          # Python version restrictions
     # Allows `setup.py test` to work correctly with pytest
     setup_requires=[] + pytest_runner,
     # Required packages, pulls from pip if needed


### PR DESCRIPTION
Python 3.9+ is required for tests, bumping from previous 3.8+