### PR TITLE
fix get_cmap deprecation

### DIFF
--- a/mdahole2/analysis/hole.py
+++ b/mdahole2/analysis/hole.py
@@ -848,7 +848,7 @@ class HoleAnalysis(AnalysisBase):
             frames = util.asiterable(frames)
 
         if color is None:
-            colormap = plt.cm.get_cmap(cmap)
+            colormap = matplotlib.colormaps.get_cmap(cmap)
             norm = matplotlib.colors.Normalize(vmin=min(frames),
                                                vmax=max(frames))
             colors = colormap(norm(frames))


### PR DESCRIPTION

2023-11-03T03:16:21.0968186Z   /home/runner/work/mdanalysis/mdanalysis/package/MDAnalysis/analysis/hole2/hole.py:874: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
