### PR TITLE
Update duecredit paths

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -97,8 +97,9 @@ jobs:
         conda info
         conda list
 
-
     - name: Run tests
+      env:
+        DUECREDIT_ENABLE: 'yes'
       run: |
         pytest -n 2 -v --cov=mdahole2 --cov-report=xml --color=yes mdahole2/tests/
 

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ ENV/
 
 # poetry
 poetry.lock
+
+# duecredit
+*.duecredit.p

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The rules for this file:
 <!-- New added features -->
 
 ### Fixed
+- Duecredit paths now point to mdahole2
 <!-- Bug fixes -->
 
 ### Changed

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -11,3 +11,4 @@ dependencies:
   - pytest-xdist
   - codecov
   - hole2
+  - duecredit

--- a/mdahole2/__init__.py
+++ b/mdahole2/__init__.py
@@ -2,6 +2,7 @@
 mdahole2
 A Python interface for the HOLE suite tools to analyze an ion channel pore or transporter pathway as a function of time or arbitrary order parameters.
 """
+from . import analysis
 
 # Handle version
 from importlib.metadata import version

--- a/mdahole2/analysis/__init__.py
+++ b/mdahole2/analysis/__init__.py
@@ -305,20 +305,21 @@ Functions and classes
               :func:``hole`` on each of them.
 
 """
-from MDAnalysis.due import due, Doi
 from .hole import hole, HoleAnalysis
 from .utils import create_vmd_surface
 
+from MDAnalysis.due import due, Doi
+
 due.cite(Doi("10.1016/S0006-3495(93)81293-1"),
          description="HOLE program",
-         path="mdahole2.analysis.hole2",
+         path="mdahole2.analysis.hole",
          cite_module=True)
 due.cite(Doi("10.1016/S0263-7855(97)00009-X"),
          description="HOLE program",
-         path="mdahole2.analysis.hole2",
+         path="mdahole2.analysis.hole",
          cite_module=True)
 due.cite(Doi("10.1016/j.jmb.2013.10.024"),
          description="HOLE trajectory analysis with orderparameters",
-         path="mdahole2.analysis.hole2",
+         path="mdahole2.analysis.hole",
          cite_module=True)
 del Doi

--- a/mdahole2/analysis/__init__.py
+++ b/mdahole2/analysis/__init__.py
@@ -311,14 +311,14 @@ from .utils import create_vmd_surface
 
 due.cite(Doi("10.1016/S0006-3495(93)81293-1"),
          description="HOLE program",
-         path="MDAnalysis.analysis.hole2",
+         path="mdahole2.analysis.hole2",
          cite_module=True)
 due.cite(Doi("10.1016/S0263-7855(97)00009-X"),
          description="HOLE program",
-         path="MDAnalysis.analysis.hole2",
+         path="mdahole2.analysis.hole2",
          cite_module=True)
 due.cite(Doi("10.1016/j.jmb.2013.10.024"),
          description="HOLE trajectory analysis with orderparameters",
-         path="MDAnalysis.analysis.hole2",
+         path="mdahole2.analysis.hole2",
          cite_module=True)
 del Doi

--- a/mdahole2/tests/test_duecredit.py
+++ b/mdahole2/tests/test_duecredit.py
@@ -1,0 +1,26 @@
+import os
+import importlib
+import pytest
+import mdahole2
+
+pytest.importorskip('duecredit')
+
+
+@pytest.mark.skipif((os.environ.get('DUECREDIT_ENABLE', 'no').lower()
+                     in ('no', '0', 'false')),
+                     reason="duecredit is disabled")
+class TestDuecredit:
+    def test_duecredit_active(self):
+        assert mdahole2.analysis.due.active
+
+    def test_duecredit_collection(self):
+        importlib.import_module('mdahole2.analysis.hole')
+
+        dois = [
+            "10.1016/s0006-3495(93)81293-1",
+            "10.1016/s0263-7855(97)00009-x",
+            "10.1016/j.jmb.2013.10.024"
+        ]
+
+        for doi in dois:
+            assert mdahole2.analysis.due.citations[("mdahole2.analysis.hole", doi)].cites_module


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

We agreed in https://github.com/MDAnalysis/PathSimAnalysis/pull/12 that we probably don't need to vendor duecredit in the kits, but we should at least make sure we point to the right module.

Changes made in this Pull Request:
 - Update duecredit paths

TODO:
- Tests
- Changelog


PR Checklist
------------
 - [ ] Tests?
 - Docs?
 - [ ] CHANGELOG updated?
 - Issue raised/referenced?
